### PR TITLE
Fix d'un bug qui faisait crash l'API

### DIFF
--- a/MenApi.py
+++ b/MenApi.py
@@ -54,8 +54,5 @@ class MenApi:
     def dejeuners(self, date: datetime.datetime) -> list[str]:
         return self.parse_text(self.get_page(date, moment='dejeuners'), date)
 
-    def get_at_date_soir(self, date: datetime.datetime) -> list[str]:
-        return self.parse_text(self.get_page(date, moment='diners'), date)
-
-    def get_at_date_midi(self, date: datetime.datetime) -> list[str]:
-        return self.parse_text(self.get_page(date, moment='dejeuners'), date)
+    get_at_date_soir = diners
+    get_at_date_midi = dejeuners

--- a/MenApi.py
+++ b/MenApi.py
@@ -3,6 +3,9 @@ from bs4 import BeautifulSoup
 import unidecode
 import datetime
 import urllib.parse
+from contextlib import suppress
+
+
 class MenApi:
     def __init__(self, base_url='https://hoche.thewebanswer.net/') -> None:
         self.base_url = base_url
@@ -21,40 +24,38 @@ class MenApi:
             'decembre': '12',
         }
 
-    def get_page(self, date: datetime.datetime, moment='diners') -> str:
+    def get_page(self, date: datetime.datetime, moment='dejeuners') -> str:
+        return requests.get(self.base_url + urllib.parse.quote(f'repas/semaines/{moment}/{date.year}-{date.month}-{date.day}')).text
 
-        req = requests.get(self.base_url + urllib.parse.quote(f'repas/semaines/{moment}/{date.year}-{date.month}-{date.day}'))
-        return req.text
-    
     def parse_text(self, content: str, date: datetime.datetime) -> list[str]:
         page_bs4 = BeautifulSoup(content, 'html.parser')
-        page_bs4.body.main.section.h2.contents[0].split('du')[1].split('au')
+        try:
+            page_bs4.body.main.section.h2.contents[0].split('du')[1].split('au')
+        except IndexError:
+            return []  # le menu après n'est plus disponible (page se connecter à l'administration)
         text_start = page_bs4.body.main.section.h2.text.replace('\n', '').split(' du ')[1].split(' au ')[0].strip().split(' ')
-        
         start_date = datetime.datetime(date.year, int(self.corresp[unidecode.unidecode(text_start[1].lower())]), int(text_start[0]))
-        # end_date = (date.year, int(self.corresp[unidecode.unidecode(dates_semaines[1].split(' ')[2].lower())]), int(dates_semaines[1].split(' ')[1]))
         num_item = (date - start_date).days
         menu = []
         for tr in page_bs4.body.main.find('table').tbody.findAll('tr'):
             poss = ''
-            try:
+            with suppress(IndexError):  # Si le jour existe pas
                 for posibilite in tr.findAll('td')[num_item].findAll('p'):
                     poss += posibilite.text.strip() + ' / '
                 if poss == '':
                     for posibilite in tr.findAll('td')[num_item].findAll('span'):
                         poss += posibilite.text.strip() + ' / '
                 menu.append(poss[:-3])
-            except IndexError:
-                pass
-                # Le jour existe pas
-
         return menu
 
-    def get_at_date_midi(self, date: datetime.datetime) -> list[str]:
+    def diners(self, date: datetime.datetime) -> list[str]:
+        return self.parse_text(self.get_page(date, moment='diners'), date)
+
+    def dejeuners(self, date: datetime.datetime) -> list[str]:
         return self.parse_text(self.get_page(date, moment='dejeuners'), date)
-    
+
     def get_at_date_soir(self, date: datetime.datetime) -> list[str]:
         return self.parse_text(self.get_page(date, moment='diners'), date)
 
-# client = MenApi()
-# print(client.get_at_date_midi(datetime.datetime(2023, 12, 4)))
+    def get_at_date_midi(self, date: datetime.datetime) -> list[str]:
+        return self.parse_text(self.get_page(date, moment='dejeuners'), date)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Retourne une liste vide si le jour n'est pas dans le menu.
 ## Exemple
 ```Python
 >>> client = MenApi()
->>> client.get_at_date_midi(datetime.datetime(2023, 12, 12))
+>>> client.dejeuners(datetime.datetime(2023, 12, 12))
 ['Entrée', 'Plat', 'Accompagnement', 'Laitage', 'Dessert']
 ``` 
 


### PR DESCRIPTION
Hello,
En utilisant l'API, j'ai trouvé un bug qui fait crash l'API à cause de la page "Connexion à l'administration" quand on demande un menu trop loin dans le temps.
J'ai réglé ce bug dans le code et j'ai changé quelques lignes qu'on pouvait optimiser / rendre plus lisibles.
J'ai rajouté deux alias parce que `.get_at_date_soir()` et `.get_at_date_midi()` n'étaient pas très intuitifs : `.dejeuners()` et `.diners()` comme ça les nouveaux arrivants auront un README plus parlant et les vieux projets fonctionneront toujours grâce aux alias.